### PR TITLE
Ensure return values same shape as recieved

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ Pass an API key for this app (not one for BreatheHR) via the `X-Api-Key` header
 The API has four endpoints:
 
 #### `/employees`
+
 Returns a JSON array of the emails and IDs of all employees.
 
-#### `/absences`, `/sicknesses`, `/trainings`
-Each return a JSON array of all
-absences/sicknesses/trainings. Use the filter parameter `employee_id` to limit
-to a particular employee, and `after` with a YYYY-MM-DD date to limit the age of
-items
+#### `/absences`, `/sicknesses`, `/employee_training_courses`
+
+Each return a JSON array of all absences/sicknesses/trainings. Use the filter
+parameter `employee_id` to limit to a particular employee, and `after` with a
+YYYY-MM-DD date to limit the age of items
 
 ```
 /absences?employee_id=123&after=2023-04-06

--- a/lib/redacted_breathe_client.rb
+++ b/lib/redacted_breathe_client.rb
@@ -13,60 +13,72 @@ class RedactedBreatheClient
     end
 
     def employees
-      client
-        .employees
-        .list
-        .response
-        .data[:employees]
-        .map { |employee| employee.to_hash.slice(:id, :email) } # This is very important for concealing private information
+      {employees:
+        client
+          .employees
+          .list
+          .response
+          .data[:employees]
+          .map { |employee|
+          employee.to_hash.slice( # This is very important for concealing private information
+            :id,
+            :email
+          )
+        }}
     rescue => error
       raise unless rate_limited?(error)
       raise RateLimited
     end
 
     def absences(employee_id:, after:)
-      client
-        .absences
-        .list(
-          employee_id: employee_id,
-          start_date: after,
-          exclude_cancelled_absences: true
-        )
-        .response
-        .data[:absences]
-        .map(&:to_hash)
+      {absences:
+        client
+          .absences
+          .list(
+            employee_id: employee_id,
+            start_date: after,
+            exclude_cancelled_absences: true
+          )
+          .response
+          .data[:absences]
+          .map(&:to_hash)
+        }
     rescue => error
       raise unless rate_limited?(error)
       raise RateLimited
     end
 
     def sicknesses(employee_id:, after:)
-      client
-        .sicknesses
-        .list(
-          employee_id: employee_id,
-          start_date: after,
-          exclude_cancelled_sicknesses: true
-        )
-        .response
-        .data[:sicknesses]
-        .map(&:to_hash)
+      {sicknesses:
+        client
+          .sicknesses
+          .list(
+            employee_id: employee_id,
+            start_date: after,
+            exclude_cancelled_sicknesses: true
+          )
+          .response
+          .data[:sicknesses]
+          .map(&:to_hash)
+        }
     rescue => error
       raise unless rate_limited?(error)
       raise RateLimited
     end
 
-    def trainings(employee_id:, after:)
-      client
-        .employee_training_courses
-        .list(
-          employee_id: employee_id,
-          start_date: after,
-          exclude_cancelled_employee_training_courses: true
-        )
-        .response
-        .data[:employee_training_courses]
-        .map(&:to_hash)
+    def employee_training_courses(employee_id:, after:)
+      {employee_training_courses:
+        client
+          .employee_training_courses
+          .list(
+            employee_id: employee_id,
+            start_date: after,
+            exclude_cancelled_employee_training_courses: true
+          )
+          .response
+          .data[:employee_training_courses]
+          .map(&:to_hash)
+        }
     rescue => error
       raise unless rate_limited?(error)
       raise RateLimited

--- a/lib/redacted_breathe_client.rb
+++ b/lib/redacted_breathe_client.rb
@@ -41,8 +41,18 @@ class RedactedBreatheClient
           )
           .response
           .data[:absences]
-          .map(&:to_hash)
-        }
+          .map { |absence|
+          absence.to_hash.slice( # This is very important for concealing private information
+            :id,
+            :start_date,
+            :half_start,
+            :half_start_am_pm,
+            :end_date,
+            :half_end,
+            :half_end_am_pm,
+            :cancelled
+          )
+        }}
     rescue => error
       raise unless rate_limited?(error)
       raise RateLimited
@@ -59,8 +69,18 @@ class RedactedBreatheClient
           )
           .response
           .data[:sicknesses]
-          .map(&:to_hash)
-        }
+          .map { |sickness|
+          sickness.to_hash.slice(
+            :id,
+            :start_date,
+            :half_start,
+            :half_start_am_pm,
+            :end_date,
+            :half_end,
+            :half_end_am_pm,
+            :status
+          )
+        }}
     rescue => error
       raise unless rate_limited?(error)
       raise RateLimited
@@ -77,8 +97,17 @@ class RedactedBreatheClient
           )
           .response
           .data[:employee_training_courses]
-          .map(&:to_hash)
-        }
+          .map { |training|
+          training.to_hash.slice(
+            :id,
+            :start_on,
+            :end_on,
+            :half_day,
+            :half_day_am_pm,
+            :hours,
+            :status
+          )
+        }}
     rescue => error
       raise unless rate_limited?(error)
       raise RateLimited

--- a/spec/redacted_spec.rb
+++ b/spec/redacted_spec.rb
@@ -1,0 +1,35 @@
+require_relative "../lib/redacted_breathe_client"
+describe "client" do
+  let(:mockclient) { double }
+  before do
+    allow(RedactedBreatheClient).to receive(:client).and_return(mockclient)
+  end
+
+  describe "employees" do
+    it "has the right shape and redacts secrets" do
+      allow(mockclient).to receive_message_chain(:employees, :list, :response, :data).and_return({employees: [{id: 3, email: 6, secret: "kittens!"}], bad: "no"})
+      expect(RedactedBreatheClient.employees).to eq({employees: [{id: 3, email: 6}]})
+    end
+  end
+
+  describe "absenses" do
+    it "has the right shape" do
+      allow(mockclient).to receive_message_chain(:absences, :list, :response, :data).and_return({absences: [{id: 3, start_date: "2015-07-10 00:00:00 +0100", secret: "kittens!"}], bad: "no"})
+      expect(RedactedBreatheClient.absences(employee_id: 9, after: "2022-02-22")).to eq({absences: [{id: 3, start_date: "2015-07-10 00:00:00 +0100"}]})
+    end
+  end
+
+  describe "sicknesses" do
+    it "has the right shape" do
+      allow(mockclient).to receive_message_chain(:sicknesses, :list, :response, :data).and_return({sicknesses: [{id: 3, start_date: "2015-07-10 00:00:00 +0100", secret: "kittens!"}], bad: "no"})
+      expect(RedactedBreatheClient.sicknesses(employee_id: 9, after: "2022-02-22")).to eq({sicknesses: [{id: 3, start_date: "2015-07-10 00:00:00 +0100"}]})
+    end
+  end
+
+  describe "employee_training_courses" do
+    it "has the right shape" do
+      allow(mockclient).to receive_message_chain(:employee_training_courses, :list, :response, :data).and_return({employee_training_courses: [{id: 3, start_on: "2015-07-10 00:00:00 +0100", secret: "kittens!"}], bad: "no"})
+      expect(RedactedBreatheClient.employee_training_courses(employee_id: 9, after: "2022-02-22")).to eq({employee_training_courses: [{id: 3, start_on: "2015-07-10 00:00:00 +0100"}]})
+    end
+  end
+end


### PR DESCRIPTION
The real Breathe API returns data in a specific format. This PR changes the response of the redacted API to align with that format so that it's easy to replace the real API with the redacted one in consuming systems.

Currently the redacted API receives `{"employees": [employee_list]}` but returns `[redacted_employee_list]`; we instead return `{"employees": [redacted_employee_list]}` to make the API more transparently like the real Breathe API.

Previously we were only redacted the `employees` endpoint, but on further inspection it makes sense to redact all the endpoints so we are only passing through necessary information.