### PR TITLE
Change API key header from Authorization to X-Api-Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ data, only a handful of people have access to it.
 ## API
 
 ### Authorization
-Use bearer token authorisation with an API key for this app (not one for
-BreatheHR)
+
+Pass an API key for this app (not one for BreatheHR) via the `X-Api-Key` header
 
 ### Endpoints
 

--- a/api.rb
+++ b/api.rb
@@ -7,7 +7,7 @@ require "sinatra"
 require "sinatra/json"
 
 def valid_key?(key)
-  key.split[1] === ENV.fetch("MIDDLEMAN_API_KEY")
+  key === ENV.fetch("MIDDLEMAN_API_KEY")
 end
 
 def ensure_key_is_set
@@ -20,7 +20,7 @@ ensure_key_is_set
 # Routing
 
 before do
-  error 401, "API key invalid" unless valid_key?(request.env["HTTP_AUTHORIZATION"])
+  error 401, "API key invalid" unless valid_key?(request.env["HTTP_X_API_KEY"])
 end
 
 get "/employees" do


### PR DESCRIPTION
The Breathe API looks in the `X-Api-Key` header for an API key. Currently the redacted API uses the `Authorization` header with bearer token instead. This PR changes that behaviour so that it match Breathe's real behaviour for easy of switching between the two.