### PR TITLE
Fix trainings API call

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -42,7 +42,7 @@ rescue RateLimited
 end
 
 get "/employee_training_courses" do
-  json RedactedBreatheClient.trainings(employee_id: params[:employee_id], after: params[:after])
+  json RedactedBreatheClient.employee_training_courses(employee_id: params[:employee_id], after: params[:after])
 rescue RateLimited
   halt(420, "Redacted API: Rate limited")
 end


### PR DESCRIPTION
Commit bf1ba5e renamed the redacted API client's method `trainings` to `employee_training_courses`, but did not update the method call from the corresponding path of the redacted API.

Fix method call.

I've tried to set up testing for the Sinatra app, but it's turning into a bigger thing, so in the interest of being able to debug missing events from Productive, I'm leaving it for later development.