### PR TITLE
Add missing attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux

--- a/lib/redacted_breathe_client.rb
+++ b/lib/redacted_breathe_client.rb
@@ -44,6 +44,8 @@ class RedactedBreatheClient
           .map { |absence|
           absence.to_hash.slice( # This is very important for concealing private information
             :id,
+            :leave_reason,
+            :type,
             :start_date,
             :half_start,
             :half_start_am_pm,


### PR DESCRIPTION
Holiday events read via the redacted API end up as "other leave",
because the slicing had missed out on the `type` attribute.

Add back `leave_reason` as well, used to determine the absence is of a
deprecated kind and should be ignored.